### PR TITLE
Feature/remove ucsdlib.java

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Solr Installation Options:
 * `solr_download_dir`: Temporary directory to download and extract (default: /tmp/solr)
 * `solr_set_default`: Set "/opt/solr" symlink (default: true)
 * `solr_set_usr_bin`: Set "/usr/local/bin/solr" symlink (default: false)
-* `solr_webproxy`: Webproxy to use (default: _none_)
 
 Dependencies
 ------------
@@ -51,6 +50,14 @@ to be writable by the calling user (or at least the files directory within the
 role).
 
 `ansible-playbook roles/ucsdlib.solr/helpers/download.yml`
+
+Use the `environment:` keyword to set a proxy.
+
+    - hosts: servers
+      environment:
+        http_proxy: http://webproxy:3128/
+      roles:
+        - role: ucsdlib.solr
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Requires Java, which is installed via dependency.
 Role Variables
 --------------
 
-* `solr_version`: Version to install (default: 6.3.0)
+* `solr_version`: Version to install (default: 7.4.0)
 * `solr_mirror`: Mirror to download from (default: http://archive.apache.org/dist/)
 * `solr_start`: Flag to start the Solr service immediately (defaut: true)
 * `solr_enable`: Flag to start Solr at boot (default: true)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installs Apache Solr from upstream release.
 Requirements
 ------------
 
-Requires Java, which is installed via dependency.
+Requires Java.
 
 Role Variables
 --------------
@@ -29,10 +29,6 @@ Solr Installation Options:
 * `solr_set_default`: Set "/opt/solr" symlink (default: true)
 * `solr_set_usr_bin`: Set "/usr/local/bin/solr" symlink (default: false)
 
-Dependencies
-------------
-
-Uses ucsdlib.java to install java, and sets `/usr/local/bin` symlink.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ucsdlib.solr
 
-solr_version: 6.3.0
+solr_version: 7.4.0
 
 solr_mirror: http://archive.apache.org/dist/
 # http://archive.apache.org/dist/ is the upstream

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,7 +19,4 @@ solr_user: solr
 solr_download_dir: /tmp/solr
 solr_set_default: true
 solr_set_usr_bin: false
-solr_webproxy: {}
-#  http_proxy: http://webproxy:3128/'
-# If you use this, rememer to remove the {}
 #solr_memory: 4G

--- a/helpers/download.yml
+++ b/helpers/download.yml
@@ -16,5 +16,3 @@
       url: '{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_tarball }}'
       dest: '../files/{{ solr_tarball }}'
       force: '{{ solr_force_download | default (false) }}'
-    environment:
-      '{{ solr_webproxy | default ({}) }}'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,9 +16,6 @@ galaxy_info:
   #  - trusty
   #  - xenial
 
-  galaxy_tags:
-  - hydra
-
 dependencies:
   - name: ucsdlib.java
     java_set_compatibility_symlink: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,7 +15,3 @@ galaxy_info:
     - precise
   #  - trusty
   #  - xenial
-
-dependencies:
-  - name: ucsdlib.java
-    java_set_compatibility_symlink: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
 # tasks file for ucsdlib.solr
 
+- name: Get java version
+  command: java -version
+  changed_when: false
+  check_mode: no
+  register: solr_java_version
+  failed_when: false
+
+- name: Ensure a java is present
+  assert:
+    that: solr_java_version.rc == 0
+  when: not ansible_check_mode
+
 - name: Install Dependencies
   package:
     name: '{{ item }}'
@@ -40,33 +52,40 @@
       - solr
       - setup
 
-  - block:
-    - name: "Copy cached tgz file, if available"
-      copy:
-       src: '{{ solr_tarball }}'
-       dest: '{{ solr_download_dir}}/solr'
-      tags:
-        - solr
-        - setup
+  - name: Check for cached tarball
+    stat:
+      path: '{{ role_path }}/files/{{ solr_tarball }}'
+    register: solr_tgz_cached
+    connection: local
+    tags:
+      - solr
+      - setup
 
-    rescue:
+  - name: "Copy cached tarball file, if available"
+    copy:
+      src: '{{ solr_tarball }}'
+      dest: '{{ solr_download_dir }}/solr'
+    when: solr_tgz_cached.stat.exists
+    tags:
+      - solr
+      - setup
 
-    - name: "Download Upstream tgz file"
-      get_url:
-        url: '{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_tarball }}'
-        dest: '{{ solr_download_dir }}/solr/{{ solr_tarball }}'
-        force: yes
-      environment:
-        '{{ solr_webproxy | default ({}) }}'
-      tags:
-        - solr
-        - setup
+  - name: "Download Upstream tarball"
+    get_url:
+      url: '{{ solr_mirror }}/lucene/solr/{{ solr_version }}/{{ solr_tarball }}'
+      dest: '{{ solr_download_dir }}/solr/{{ solr_tarball }}'
+      force: yes
+    when: not solr_tgz_cached.stat.exists
+    tags:
+      - solr
+      - setup
 
   - name: Unpack Solr
     unarchive:
       src: '{{ solr_download_dir }}/solr/{{ solr_tarball }}'
       dest: '{{ solr_download_dir }}/solr'
       copy: no
+    when: not ansible_check_mode
     tags:
       - solr
       - setup
@@ -103,7 +122,9 @@
     path: '{{ solr_install_dir }}/solr'
     src: '{{ solr_install_dir ~ "/" ~ solr_directory }}'
     state: link
-  when: solr_set_default
+  when:
+    - solr_set_default
+    - not ansible_check_mode
   ignore_errors: '{{ ansible_check_mode }}'
   tags:
     - solr
@@ -113,6 +134,8 @@
   service:
     name: solr
     enabled: '{{ solr_enable }}'
+  when:
+    - ansible_system != "Darwin"
   tags:
     - solr
 
@@ -120,6 +143,8 @@
   service:
     name: solr
     state: started
-  when: solr_start
+  when:
+    - solr_start
+    - ansible_system != "Darwin"
   tags:
     - solr

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,5 @@
 ---
 - hosts: localhost
-  remote_user: root
+  connection: local
   roles:
      - ansible-role-solr


### PR DESCRIPTION
Removes ucsd lib.java role dependency
Removes scary error when cached tarball is missing
--check works, at least on macOS